### PR TITLE
Repalce s3.IsDirectory and GetDirectory use of ListObjectsV2 with ListObjects

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -144,7 +144,7 @@ func (s *s3client) GetDirectory(bucket, keyPrefix, path string) error {
 	keyPrefix = filepath.Clean(keyPrefix) + "/"
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	objCh := s.minioClient.ListObjectsV2(bucket, keyPrefix, true, doneCh)
+	objCh := s.minioClient.ListObjects(bucket, keyPrefix, true, doneCh)
 	for obj := range objCh {
 		if obj.Err != nil {
 			return errors.WithStack(obj.Err)
@@ -164,7 +164,7 @@ func (s *s3client) GetDirectory(bucket, keyPrefix, path string) error {
 func (s *s3client) IsDirectory(bucket, key string) (bool, error) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	objCh := s.minioClient.ListObjectsV2(bucket, key, false, doneCh)
+	objCh := s.minioClient.ListObjects(bucket, key, false, doneCh)
 	for obj := range objCh {
 		if obj.Err != nil {
 			return false, errors.WithStack(obj.Err)


### PR DESCRIPTION
Fixes [Argo #1351](https://github.com/argoproj/argo/issues/1351)

minioClient.ListObjectsV2 is not supported by Google Cloud Storage.  s3.IsDirectory and s3.GetDirectory both use ListObjectsV2 to query objects by key prefix.  This gets an error response from GCS.  minioClient.ListObjects is supported by GCS and resolves the above failure in Argo artifact handling for 'directories' of objects.