### PR TITLE
fix: fix nil pointer de-reference in k8s metrics transport wrapper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -612,6 +612,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/dustin/go-humanize",

--- a/kubeclientmetrics/metric.go
+++ b/kubeclientmetrics/metric.go
@@ -126,7 +126,9 @@ func handleCreate(r *http.Request) ResourceInfo {
 func (mrt *metricsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, roundTimeErr := mrt.roundTripper.RoundTrip(r)
 	info := parseRequest(r)
-	info.StatusCode = resp.StatusCode
+	if resp != nil {
+		info.StatusCode = resp.StatusCode
+	}
 	_ = mrt.inc(info)
 	return resp, roundTimeErr
 }


### PR DESCRIPTION
PR fixes nil pointer dereference error.

<details>
  <summary>Sample stack trace:</summary>
  
```
time="2020-03-18T22:08:22Z" level=error msg="Recovered from panic: runtime error: invalid memory address or nil pointer dereference
goroutine 248 [running]:
runtime/debug.Stack(0xc0c8c4f0c0, 0x1b79de0, 0x3252b50)
    /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/argoproj/argo-cd/controller.(*ApplicationController).processRequestedAppOperation.func1(0xc0a75c3a40, 0xc0c8c51cc8, 0xc000425400, 0xc0c8c51d68)
    /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:664 +0x5a
panic(0x1b79de0, 0x3252b50)
    /usr/local/go/src/runtime/panic.go:967 +0x15d
github.com/argoproj/pkg/kubeclientmetrics.(*metricsRoundTripper).RoundTrip(0xc241f79800, 0xc0e2861800, 0x1df2012, 0xd, 0xc1b0eab558)
    /go/src/github.com/argoproj/pkg/kubeclientmetrics/metric.go:129 +0xb6
k8s.io/client-go/transport.(*bearerAuthRoundTripper).RoundTrip(0xc0f838cae0, 0xc0e2861700, 0x1dee343, 0xa, 0xc1b0eab3e0)
    /go/src/k8s.io/client-go/transport/round_trippers.go:297 +0x266
k8s.io/client-go/transport.(*userAgentRoundTripper).RoundTrip(0xc241f79820, 0xc0e2861600, 0xc241f79820, 0xbf94c4d5b1119fa3, 0x2aaee3d0dde)
    /go/src/k8s.io/client-go/transport/round_trippers.go:159 +0x1c0
net/http.send(0xc0e2861500, 0x20ea400, 0xc241f79820, 0xbf94c4d5b1119fa3, 0x2aaee3d0dde, 0x327a820, 0xc1c76c8200, 0xbf94c4d5b1119fa3, 0x1, 0x0)
    /usr/local/go/src/net/http/client.go:252 +0x43e
net/http.(*Client).send(0xc0f838cb10, 0xc0e2861500, 0xbf94c4d5b1119fa3, 0x2aaee3d0dde, 0x327a820, 0xc1c76c8200, 0x0, 0x1, 0xc1efdd21f0)
    /usr/local/go/src/net/http/client.go:176 +0xfa
net/http.(*Client).do(0xc0f838cb10, 0xc0e2861500, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/client.go:699 +0x44a
net/http.(*Client).Do(0xc0f838cb10, 0xc0e2861500, 0x0, 0x21317a0, 0xc2505d4cc0)
    /usr/local/go/src/net/http/client.go:567 +0x35
k8s.io/client-go/rest.(*Request).request(0xc19617db00, 0xc0c8c4fa20, 0x0, 0x0)
    /go/src/k8s.io/client-go/rest/request.go:754 +0x367
k8s.io/client-go/rest.(*Request).Do(0xc19617db00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/k8s.io/client-go/rest/request.go:828 +0xd8
k8s.io/client-go/discovery.(*DiscoveryClient).ServerResourcesForGroupVersion(0xc241f798e0, 0xc069f15e00, 0x1c, 0x1de4dc6, 0x1, 0xc0392bef1a)
    /go/src/k8s.io/client-go/discovery/discovery_client.go:199 +0x1b9
github.com/argoproj/argo-cd/util/kube.ServerResourceForGroupVersionKind(0x214cb20, 0xc241f798e0, 0xc0392bef00, 0x19, 0xc0392bef1a, 0x2, 0xc0f08b53fc, 0x4, 0x1f, 0xc0f08b5fd0, ...)
    /go/src/github.com/argoproj/argo-cd/util/kube/kube.go:239 +0xbc
github.com/argoproj/argo-cd/controller.(*syncContext).getSyncTasks(0xc0006e3c70, 0xc01d03ce48, 0x1, 0x1, 0xc01d03d150)
    /go/src/github.com/argoproj/argo-cd/controller/sync.go:476 +0xeda
github.com/argoproj/argo-cd/controller.(*syncContext).sync(0xc0006e3c70)
    /go/src/github.com/argoproj/argo-cd/controller/sync.go:210 +0x2b9
github.com/argoproj/argo-cd/controller.(*appStateManager).SyncAppState(0xc0006c2000, 0xc02f82b180, 0xc0d0a32460)
    /go/src/github.com/argoproj/argo-cd/controller/sync.go:194 +0x1051
github.com/argoproj/argo-cd/controller.(*ApplicationController).processRequestedAppOperation(0xc000425400, 0xc02f82b180)
    /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:697 +0x2ea
github.com/argoproj/argo-cd/controller.(*ApplicationController).processAppOperationQueueItem(0xc000425400, 0x53223a2273757401)
    /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:499 +0x495
github.com/argoproj/argo-cd/controller.(*ApplicationController).Run.func4()
    /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:429 +0x36
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000bcec90)
    /go/src/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000bcec90, 0x3b9aca00, 0x0, 0x223a22646e696b01, 0xc0000b8ae0)
    /go/src/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000bcec90, 0x3b9aca00, 0xc0000b8ae0)
    /go/src/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by github.com/argoproj/argo-cd/controller.(*ApplicationController).Run
    /go/src/github.com/argoproj/argo-cd/controller/appcontroller.go:428 +0x43e
" application=argocd-argo
```
  
</details>

