### PR TITLE
feat: adds SetLogTimestampFormat to cli, implements #2795

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,10 +11,10 @@ import (
 )
 
 // SetLogTimestampFormat sets the format of log timestamps
-func SetLogTimestampFormat(format string) {
+func SetLogTimestampFormat(format string, full bool) {
 	log.SetFormatter(&log.TextFormatter{
 		TimestampFormat: format,
-		FullTimestamp:   true,
+		FullTimestamp:   full,
 	})
 }
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,6 +10,14 @@ import (
 	"github.com/argoproj/pkg/errors"
 )
 
+// SetLogTimestampFormat sets the format of log timestamps
+func SetLogTimestampFormat(format string) {
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: format,
+		FullTimestamp:   true,
+	})
+}
+
 // SetLogLevel parses and sets a logrus log level
 func SetLogLevel(logLevel string) {
 	level, err := log.ParseLevel(logLevel)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSetLogTimestampFormat
+func TestSetLogTimestampFormat(t *testing.T) {
+	message, _ := log.NewEntry(log.StandardLogger()).String()
+	assert.Contains(t, message, "0001-01-01T00:00:00Z")
+
+	SetLogTimestampFormat("2006-01-02T15:04:05.000Z")
+
+	message, _ = log.NewEntry(log.StandardLogger()).String()
+	assert.Contains(t, message, "0001-01-01T00:00:00.000Z")
+
+	SetLogTimestampFormat("01-02-2006T15:04Z")
+
+	message, _ = log.NewEntry(log.StandardLogger()).String()
+	assert.Contains(t, message, "01-01-0001T00:00Z")
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -12,12 +12,12 @@ func TestSetLogTimestampFormat(t *testing.T) {
 	message, _ := log.NewEntry(log.StandardLogger()).String()
 	assert.Contains(t, message, "0001-01-01T00:00:00Z")
 
-	SetLogTimestampFormat("2006-01-02T15:04:05.000Z")
+	SetLogTimestampFormat("2006-01-02T15:04:05.000Z", true)
 
 	message, _ = log.NewEntry(log.StandardLogger()).String()
 	assert.Contains(t, message, "0001-01-01T00:00:00.000Z")
 
-	SetLogTimestampFormat("01-02-2006T15:04Z")
+	SetLogTimestampFormat("01-02-2006T15:04Z", true)
 
 	message, _ = log.NewEntry(log.StandardLogger()).String()
 	assert.Contains(t, message, "01-01-0001T00:00Z")


### PR DESCRIPTION
This PR moves towards addressing Argo Workflows [Issue #2796](https://github.com/argoproj/argo/issues/2795).

It adds the function `SetLogTimestampFormat` which could easily be called with the desired millisecond timestamp format requested in the issue, but can be formatted in any way desired by users across the various `argoproj` repositories.  The fact that it is a separate function means it will not break any existing code using `pkg`.

/review @alexec @simster7 