### PR TITLE
fix(s3): Correct key on windows

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -196,6 +196,10 @@ func (s *s3client) GetFile(bucket, key, path string) error {
 func (s *s3client) GetDirectory(bucket, keyPrefix, path string) error {
 	log.Infof("Getting directory from s3 (endpoint: %s, bucket: %s, key: %s) to %s", s.Endpoint, bucket, keyPrefix, path)
 	keyPrefix = filepath.Clean(keyPrefix) + "/"
+	if os.PathSeparator == '\\' {
+		keyPrefix = strings.ReplaceAll(keyPrefix, "\\", "/")
+	}
+
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 	listOpts := minio.ListObjectsOptions{


### PR DESCRIPTION
As `filepath.Clean` uses the `os.PathSeparator`, artifact keys like 
`artifact-passing-windows-27z9t/artifact-passing-windows-27z9t-2792197756/foobar` get altered to `artifact-passing-windows-27z9t\artifact-passing-windows-27z9t-2792197756\foobar` when running on Windows (slashes get converted to backslashes). 

Through this, the artifact download of directories within Windows containers fails like here: https://github.com/argoproj/argo/issues/3682#issuecomment-670529620.

Maybe we could also think about if we even need the `filepath.Clean`.