### PR TITLE
fix(s3): Use cross-plattform compatible paths

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -146,7 +146,7 @@ type uploadTask struct {
 }
 
 func generatePutTasks(keyPrefix, rootPath string) chan uploadTask {
-	rootPath = filepath.Clean(rootPath) + "/"
+	rootPath = filepath.Clean(rootPath) + string(os.PathSeparator)
 	uploadTasks := make(chan uploadTask)
 	visit := func(localPath string, fi os.FileInfo, err error) error {
 		relPath := strings.TrimPrefix(localPath, rootPath)


### PR DESCRIPTION
Use `os.PathSeparator` to get cross-plattform compatible filepaths.

After merging, we would also need to create a new git tag to update Argo Workflows to the new version.