### PR TITLE
feat: Use debug log level for memory and GC stats

### DIFF
--- a/stats/stats_darwin.go
+++ b/stats/stats_darwin.go
@@ -70,7 +70,7 @@ func RegisterHeapDumper(filePath string) {
 func LogStats() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	log.Infof("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
+	log.Debugf("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
 		m.Alloc/1024, m.TotalAlloc/1024, m.Sys/1024, m.NumGC, runtime.NumGoroutine())
 
 }

--- a/stats/stats_linux.go
+++ b/stats/stats_linux.go
@@ -70,7 +70,7 @@ func RegisterHeapDumper(filePath string) {
 func LogStats() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	log.Infof("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
+	log.Debugf("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
 		m.Alloc/1024, m.TotalAlloc/1024, m.Sys/1024, m.NumGC, runtime.NumGoroutine())
 
 }

--- a/stats/stats_windows.go
+++ b/stats/stats_windows.go
@@ -32,7 +32,7 @@ func RegisterHeapDumper(filePath string) {
 func LogStats() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	log.Infof("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
+	log.Debugf("Alloc=%v TotalAlloc=%v Sys=%v NumGC=%v Goroutines=%d",
 		m.Alloc/1024, m.TotalAlloc/1024, m.Sys/1024, m.NumGC, runtime.NumGoroutine())
 
 }


### PR DESCRIPTION
Suggestion to use debug log level for the memory and GC stats since I suspect they are mostly useful for the development of Argo.