### PR TITLE
fix: keepAlive might cause nip pointer dereference panic

### DIFF
--- a/grpc/http/forwarders.go
+++ b/grpc/http/forwarders.go
@@ -195,11 +195,13 @@ func NewStreamForwarder(messageKey func(proto.Message) (string, error)) StreamFo
 		opts ...func(context.Context, http.ResponseWriter, proto.Message) error,
 	) {
 		isSSE := req.Header.Get("Accept") == "text/event-stream"
+		processCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		if isSSE {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Transfer-Encoding", "chunked")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
-			w = withKeepalive(ctx, w)
+			w = withKeepalive(processCtx, w)
 		}
 		dataByKey := make(map[string][]byte)
 		m := newMarshaler(req, isSSE)


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

The https://github.com/argoproj/pkg/pull/35 introduced `bufio.Write.Flush` call at the end of steaming call. Unfortunately method crushes if writer is closed. https://github.com/golang/go/issues/9657 We've reproduced it in Argo CD: https://github.com/argoproj/argo-cd/issues/6741

PR ensures uses child context that ends as soon as streaming processing completes which ensure  `bufio.Write.Flush` is not executed on closed context.