### PR TITLE
fix: nil pointer during flush

### DIFF
--- a/grpc/http/forwarders.go
+++ b/grpc/http/forwarders.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -139,11 +138,12 @@ type StreamForwarderFunc func(
 )
 
 func flush(flusher http.Flusher) {
-	v := reflect.ValueOf(flusher).Elem()
-	y := v.FieldByName("w")
-	if !y.IsNil() {
-		flusher.Flush()
-	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warn("recovered in flush, issue with writer inside http.ResponseWriter")
+		}
+	}()
+	flusher.Flush()
 }
 
 func writeKeepalive(w http.ResponseWriter, mut *sync.Mutex) {

--- a/grpc/http/forwarders.go
+++ b/grpc/http/forwarders.go
@@ -169,8 +169,8 @@ func keepalive(ctx context.Context, w http.ResponseWriter, mut *sync.Mutex) {
 
 	for {
 		select {
-		//case <-ctx.Done():
-		//	return
+		case <-ctx.Done():
+			return
 		case <-keepaliveTicker.C:
 			writeKeepalive(w, mut)
 		}


### PR DESCRIPTION
Fix for https://github.com/argoproj/argo-cd/issues/7576

It can happen that during Flush,  w  *bufio.Writer can be nil inside w http.ResponseWriter and it cause panic

As solution I have decided to catch panic and handle it, otherwise I need use reflection for verify nil because it is private field and it may affect performance

Like this 

`v := reflect.ValueOf(w).Elem()
		y := v.FieldByName("w")
		if !y.IsNil() {
			f.Flush()
		}`