### PR TITLE
feat: exec - parametrized signal when timeout occurs

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -43,14 +43,21 @@ func newCmdError(args string, cause error, stderr string) *CmdError {
 	return &CmdError{Args: args, Stderr: stderr, Cause: cause}
 }
 
+// TimeoutBehavior defines behavior for when the command takes longer than the passed in timeout to exit
+// By default, SIGKILL is sent to the process and it is not waited upon
 type TimeoutBehavior struct {
-	Signal     syscall.Signal
+	// Signal determines the signal to send to the process
+	Signal syscall.Signal
+	// ShouldWait determines whether to wait for the command to exit once timeout is reached
 	ShouldWait bool
 }
 
 type CmdOpts struct {
-	Timeout         time.Duration
-	Redactor        func(text string) string
+	// Timeout determines how long to wait for the command to exit
+	Timeout time.Duration
+	// Redactor redacts tokens from the output
+	Redactor func(text string) string
+	// TimeoutBehavior configures what to do in case of timeout
 	TimeoutBehavior TimeoutBehavior
 }
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -70,9 +70,9 @@ func TestRunCommandSignal(t *testing.T) {
 	defer log.SetLevel(log.InfoLevel)
 
 	var timeoutBehavior = TimeoutBehavior{Signal: syscall.SIGTERM, ShouldWait: true}
-	output, err := RunCommand("sh", CmdOpts{Timeout: 200 * time.Millisecond, TimeoutBehavior: timeoutBehavior}, "-c", "trap 'trap - SIGTERM && echo captured && exit' SIGTERM && sleep 2")
+	output, err := RunCommand("sh", CmdOpts{Timeout: 200 * time.Millisecond, TimeoutBehavior: timeoutBehavior}, "-c", "trap 'trap - 15 && echo captured && exit' 15 && sleep 2")
 	assert.Equal(t, "captured", output)
-	assert.EqualError(t, err, "`sh -c trap 'trap - SIGTERM && echo captured && exit' SIGTERM && sleep 2` failed timeout after 200ms")
+	assert.EqualError(t, err, "`sh -c trap 'trap - 15 && echo captured && exit' 15 && sleep 2` failed timeout after 200ms")
 
 	assert.Len(t, hook.Entries, 3)
 }


### PR DESCRIPTION
As seen on https://github.com/argoproj/argo-cd/issues/7898#issuecomment-1353207895, sending `SIGKILL` to `git` processes could leave the local checkout in a locked state.

As also shown in that comment, by passing `SIGTERM` to the `git checkout` process, it is given a chance to gracefully shutdown, leaving the checkout in a state that future operations can succeed.

`SIGKILL` remains as the default signal for timeouts.

--

I'm not too convinced about the `ShouldWait`... it seems reasonable to expect the caller to know if the process should be waited upon or not - in any case, it was a nice way to write the test case for the new functionality.