### PR TITLE
churn: fix exec test under go 1.17+

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: 1.19
 
       - name: Build
         run: |

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -99,14 +99,12 @@ func TestRunCommandExitErr(t *testing.T) {
 }
 
 func TestRunCommandErr(t *testing.T) {
-	//_ := test.NewGlobal()
 	log.SetLevel(log.DebugLevel)
 	defer log.SetLevel(log.InfoLevel)
 
-	// this would create a panic
-	output, err := RunCommand("", CmdOpts{Redactor: Redact([]string{"world"})})
+	output, err := RunCommand("sh", CmdOpts{Redactor: Redact([]string{"world"})}, "-c", ">&2 echo 'failure'; false")
 	assert.Empty(t, output)
-	assert.EqualError(t, err, "fork/exec : no such file or directory")
+	assert.EqualError(t, err, "`sh -c >&2 echo 'failure'; false` failed exit status 1: failure")
 }
 
 func TestRunInDir(t *testing.T) {


### PR DESCRIPTION
A recent change in go https://go-review.googlesource.com/c/go/+/403759 changed the behaviour of `os/exec` which the existing test depended on.

In this PR:

* We upgrade the go version used in the `go` workflow
* Improve the test so that it actually tests the error handling of the `exec` module of this package