### PR TITLE
feat: expose http transport to callers

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ func TestNewS3Client(t *testing.T) {
 		Endpoint:        "foo.com",
 		Region:          "us-south-3",
 		Secure:          false,
+		Transport:       http.DefaultTransport,
 		AccessKey:       "key",
 		SecretKey:       "secret",
 		Trace:           true,
@@ -27,6 +29,7 @@ func TestNewS3Client(t *testing.T) {
 	assert.Equal(t, opts.Endpoint, s3cli.Endpoint)
 	assert.Equal(t, opts.Region, s3cli.Region)
 	assert.Equal(t, opts.Secure, s3cli.Secure)
+	assert.Equal(t, opts.Transport, s3cli.Transport)
 	assert.Equal(t, opts.AccessKey, s3cli.AccessKey)
 	assert.Equal(t, opts.Trace, s3cli.Trace)
 	assert.Equal(t, opts.EncryptOpts, s3cli.EncryptOpts)


### PR DESCRIPTION
Needed for https://github.com/argoproj/argo-workflows/pull/11161

- Allows the caller to set transport in the options.
- Exposes the default transport from minio-go. This is useful since they have some [custom settings](https://github.com/minio/minio-go/blob/68418bf9a5bb03337c8349523a5b188feb5ff2be/transport.go#L41-L43). So the idea is that the caller can reuse as much as possible of the minio-go default transport, only customizing the specific parts they are interested in.