### PR TITLE
feat: Allow exec to capture stderr of a process

### DIFF
--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -138,3 +138,9 @@ func TestRedact(t *testing.T) {
 	assert.Equal(t, "****** ******", Redact([]string{"foo", "bar"})("foo bar"))
 	assert.Equal(t, "****** ******", Redact([]string{"foo"})("foo foo"))
 }
+
+func TestRunCaptureStderr(t *testing.T) {
+	output, err := RunCommand("sh", CmdOpts{CaptureStderr: true}, "-c", "echo hello world && echo my-error >&2 && exit 0")
+	assert.Equal(t, "hello world\nmy-error", output)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Sometimes, we need to capture stderr of a process in addition to stdout. And at the same time, we don't want to log out an error when the exit code of a command is > 0, but instead we want to handle it differently without exposing the fact to the user.