### PR TITLE
fix: possible goroutine leak in exec

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -111,7 +111,7 @@ func RunCommandExt(cmd *exec.Cmd, opts CmdOpts) (string, error) {
 		return "", err
 	}
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
 	// Start a timer


### PR DESCRIPTION
If timeout happens and ShouldWait is false (default) cmd.Wait() goroutine will stack forever on sending to **done** channel. 
The will be no receiver from **done**.
Making the channel buffered lets the goroutine exit.