### PR TITLE
Use more up-to-date and comprehensive JSONPath library

### DIFF
--- a/expr/function.go
+++ b/expr/function.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/oliveagle/jsonpath"
+	"github.com/evilmonkeyinc/jsonpath"
 )
 
 func GetExprEnvFunctionMap() map[string]interface{} {
@@ -28,7 +28,7 @@ func JsonPath(jsonStr string, path string) interface{} {
 	if err != nil {
 		panic(err)
 	}
-	value, err := jsonpath.JsonPathLookup(jsonMap, path)
+	value, err := jsonpath.Query(path, jsonMap)
 	if err != nil {
 		panic(err)
 	}

--- a/expr/function_test.go
+++ b/expr/function_test.go
@@ -27,7 +27,7 @@ func TestJsonPath(t *testing.T) {
 	simpleJson := "{\"employee\":{\"name\":\"sonoo\",\"salary\":56000,\"married\":true}}"
 	arrayJson := "{\"employees\":[{\"name\":\"Shyam\",\"email\":\"shyamjaiswal@gmail.com\",\"age\":43},{\"name\":\"Bob\",\"email\":\"bob32@gmail.com\",\"age\":42}," +
 		"{\"name\":\"Jai\",\"email\":\"jai87@gmail.com\",\"age\":44}]}"
-	
+
 	assert.Equal(t, "sonoo", JsonPath(simpleJson, "$.employee.name"))
 	assert.Equal(t, "Bob", JsonPath(arrayJson, "$.employees[1].name"))
 	assert.Equal(t, []interface{}{"Bob"}, JsonPath(arrayJson, `$.employees[?(@.name == "Bob")].name`))

--- a/expr/function_test.go
+++ b/expr/function_test.go
@@ -25,8 +25,23 @@ func TestAsStr(t *testing.T) {
 
 func TestJsonPath(t *testing.T) {
 	simpleJson := "{\"employee\":{\"name\":\"sonoo\",\"salary\":56000,\"married\":true}}"
-	arrayJson := "{\"employees\":[{\"name\":\"Shyam\",\"email\":\"shyamjaiswal@gmail.com\"},{\"name\":\"Bob\",\"email\":\"bob32@gmail.com\"}," +
-		"{\"name\":\"Jai\",\"email\":\"jai87@gmail.com\"}]}"
+	arrayJson := "{\"employees\":[{\"name\":\"Shyam\",\"email\":\"shyamjaiswal@gmail.com\",\"age\":43},{\"name\":\"Bob\",\"email\":\"bob32@gmail.com\",\"age\":42}," +
+		"{\"name\":\"Jai\",\"email\":\"jai87@gmail.com\",\"age\":44}]}"
+	
 	assert.Equal(t, "sonoo", JsonPath(simpleJson, "$.employee.name"))
 	assert.Equal(t, "Bob", JsonPath(arrayJson, "$.employees[1].name"))
+	assert.Equal(t, []interface{}{"Bob"}, JsonPath(arrayJson, `$.employees[?(@.name == "Bob")].name`))
+	assert.Equal(t, []interface{}{}, JsonPath(arrayJson, `$..[?(@.name.length == 4)].name`))
+	assert.Equal(t, []interface{}{"Shyam", "Bob", "Jai"}, JsonPath(arrayJson, `$..[0:4].name`))
+	assert.Equal(t, []interface{}{"Shyam"}, JsonPath(arrayJson, `$.employees[0:1].name`))
+	assert.Equal(t, "Jai", JsonPath(arrayJson, `$.employees[-1].name`))
+	assert.Equal(t, []interface{}{"Bob", "Jai"}, JsonPath(arrayJson, `$.employees[-2:].name`))
+	assert.Equal(t, []interface{}{"Bob", "Jai"}, JsonPath(arrayJson, `$.employees[1:].name`))
+	assert.Equal(t, []interface{}{"Shyam", "Bob", "Jai"}, JsonPath(arrayJson, `$.employees[:].name`))
+	assert.Equal(t, []interface{}{"Jai"}, JsonPath(arrayJson, `$..[2].name`))
+	assert.Equal(t, []interface{}{"Shyam", "Bob", "Jai"}, JsonPath(arrayJson, `$..[*].name`))
+	assert.Equal(t, []interface{}{"Bob"}, JsonPath(arrayJson, `$.employees[?(@.name=="Bob")].name`))
+	assert.Equal(t, []interface{}{"Shyam", "Jai"}, JsonPath(arrayJson, `$.employees[0,2].name`))
+	assert.Equal(t, []interface{}{"Shyam"}, JsonPath(arrayJson, `$.employees[?(@.age>42 && @.age<44)].name`))
+	assert.Equal(t, []interface{}{"Shyam", "Jai"}, JsonPath(arrayJson, `$.employees[?(@.age!=42)].name`))
 }

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.14
 require (
 	github.com/aws/aws-sdk-go v1.44.328
 	github.com/dustin/go-humanize v1.0.1
+	github.com/evilmonkeyinc/jsonpath v0.8.1
 	github.com/felixge/httpsnoop v1.0.3
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/golang/protobuf v1.3.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/minio/minio-go/v7 v7.0.62
-	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evilmonkeyinc/jsonpath v0.8.1 h1:W8K4t8u7aipkQE0hcTICGAdAN0Xph349LtjgSoofvVo=
+github.com/evilmonkeyinc/jsonpath v0.8.1/go.mod h1:EQhs0ZsoD4uD56ZJbO30gMTfHLQ6DEa0/5rT5Ymy42s=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -125,8 +127,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
-github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -158,6 +158,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
Recently we noticed that Argo Workflow doesn't support some JSONPath expression to extract some values from inputs. After digging a bit we found that current JSONPath library used by Argo is outdated and it does support only a fraction of the spec. After looking around for better JSONPath libraries I found this one that works for the all expressions I have tried so far: github.com/evilmonkeyinc/jsonpath

If you're also curious about other libraries you can see a comparison here but keep in mind that it's either outdated or incorrect: https://asaiyusuke.github.io/jsonpath/cburgmer-json-path-comparison/docs/index.html

Because I tried some of the JSONPath libraries listed there, including the one written by the author of the post above and most of the expressions in the comparison table didn't work. 

* As I see these changes don't cause any issue or break existing functionality. 

* I have added some test cases to cover more complex expressions.

Please let me know if there's any mistake or something I'm missing when opening a PR here.