### PR TITLE
feat: Add support for session tokens to S3 client

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -84,6 +84,7 @@ type S3ClientOpts struct {
 	Transport       http.RoundTripper
 	AccessKey       string
 	SecretKey       string
+	SessionToken    string
 	Trace           bool
 	RoleARN         string
 	RoleSessionName string
@@ -136,8 +137,13 @@ func GetAssumeRoleCredentials(opts S3ClientOpts) (*credentials.Credentials, erro
 
 func GetCredentials(opts S3ClientOpts) (*credentials.Credentials, error) {
 	if opts.AccessKey != "" && opts.SecretKey != "" {
-		log.WithField("endpoint", opts.Endpoint).Info("Creating minio client using static credentials")
-		return credentials.NewStaticV4(opts.AccessKey, opts.SecretKey, ""), nil
+		if opts.SessionToken != "" {
+			log.WithField("endpoint", opts.Endpoint).Info("Creating minio client using ephemeral credentials")
+			return credentials.NewStaticV4(opts.AccessKey, opts.SecretKey, opts.SessionToken), nil
+		} else {
+			log.WithField("endpoint", opts.Endpoint).Info("Creating minio client using static credentials")
+			return credentials.NewStaticV4(opts.AccessKey, opts.SecretKey, ""), nil
+		}
 	} else if opts.RoleARN != "" {
 		log.WithField("roleArn", opts.RoleARN).Info("Creating minio client using assumed-role credentials")
 		return GetAssumeRoleCredentials(opts)

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestNewS3Client tests the s3 construtor
+// TestNewS3Client tests the s3 constructor
 func TestNewS3Client(t *testing.T) {
 	opts := S3ClientOpts{
 		Endpoint:        "foo.com",
@@ -17,6 +17,7 @@ func TestNewS3Client(t *testing.T) {
 		Transport:       http.DefaultTransport,
 		AccessKey:       "key",
 		SecretKey:       "secret",
+		SessionToken:    "",
 		Trace:           true,
 		RoleARN:         "",
 		RoleSessionName: "",
@@ -31,6 +32,7 @@ func TestNewS3Client(t *testing.T) {
 	assert.Equal(t, opts.Secure, s3cli.Secure)
 	assert.Equal(t, opts.Transport, s3cli.Transport)
 	assert.Equal(t, opts.AccessKey, s3cli.AccessKey)
+	assert.Equal(t, opts.SessionToken, s3cli.SessionToken)
 	assert.Equal(t, opts.Trace, s3cli.Trace)
 	assert.Equal(t, opts.EncryptOpts, s3cli.EncryptOpts)
 	assert.Equal(t, opts.AddressingStyle, s3cli.AddressingStyle)
@@ -38,7 +40,26 @@ func TestNewS3Client(t *testing.T) {
 	// 	s3client.minioClient
 }
 
-// TestNewS3Client tests the s3 construtor
+// TestNewS3Client tests the S3 constructor using ephemeral credentials
+func TestNewS3ClientEphemeral(t *testing.T) {
+	opts := S3ClientOpts{
+		Endpoint:     "foo.com",
+		Region:       "us-south-3",
+		AccessKey:    "key",
+		SecretKey:    "secret",
+		SessionToken: "sessionToken",
+	}
+	s3If, err := NewS3Client(context.Background(), opts)
+	assert.NoError(t, err)
+	s3cli := s3If.(*s3client)
+	assert.Equal(t, opts.Endpoint, s3cli.Endpoint)
+	assert.Equal(t, opts.Region, s3cli.Region)
+	assert.Equal(t, opts.AccessKey, s3cli.AccessKey)
+	assert.Equal(t, opts.SecretKey, s3cli.SecretKey)
+	assert.Equal(t, opts.SessionToken, s3cli.SessionToken)
+}
+
+// TestNewS3Client tests the s3 constructor
 func TestNewS3ClientWithDiff(t *testing.T) {
 	t.Run("IAMRole", func(t *testing.T) {
 		opts := S3ClientOpts{


### PR DESCRIPTION
This PR adds support for the S3 client to use ephemeral IAM credentials (e.g. an access/secret key pair + session token obtain through an assume role operation) or to use the new [S3 access grants](https://aws.amazon.com/blogs/storage/scaling-data-access-with-amazon-s3-access-grants/) feature.

This is a pre-requisite to https://github.com/argoproj/argo-workflows/issues/5446

The relevant PR in Argo Workflows is here: https://github.com/argoproj/argo-workflows/pull/12467

I found the contributing guidelines for Argo Workflows, but couldn't find anything for this specific repo, so please let me know if anything is missing. Thank you!