### PR TITLE
fix(s3): check for errors when finding artifacts

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -252,7 +252,11 @@ func generatePutTasks(keyPrefix, rootPath string) chan uploadTask {
 	rootPath = filepath.Clean(rootPath) + string(os.PathSeparator)
 	uploadTasks := make(chan uploadTask)
 	go func() {
-		_ = filepath.Walk(rootPath, func(localPath string, fi os.FileInfo, _ error) error {
+		_ = filepath.Walk(rootPath, func(localPath string, fi os.FileInfo, err error) error {
+			if err != nil {
+				log.WithFields(log.Fields{"localPath": localPath}).Error("Failed to walk artifacts path", err)
+				return err
+			}
 			relPath := strings.TrimPrefix(localPath, rootPath)
 			if fi.IsDir() {
 				return nil


### PR DESCRIPTION
Attempt to fix https://github.com/argoproj/argo-workflows/issues/13248

`fi` is null in the stack trace, and `err` isn't being checked here. So check `err` and don't attempt to continue.