### PR TITLE
chore: deprecate trivial functions

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -5,6 +5,7 @@ import (
 )
 
 // CheckError is a convenience function to fatally log an exit if the supplied error is non-nil
+// Deprecated: this function is trivial and should be implemented by the caller instead.
 func CheckError(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/rand/rand.go
+++ b/rand/rand.go
@@ -6,6 +6,7 @@ import (
 )
 
 // RandString returns a cryptographically-secure pseudo-random alpha-numeric string of a given length
+// Deprecated: this function is trivial and should be implemented by the caller instead.
 func RandString(n int) (string, error) {
 	bytes := make([]byte, n/2+1) // we need one extra letter to discard
 	if _, err := rand.Read(bytes); err != nil {


### PR DESCRIPTION
These functions are trivial. Having them in this repo introduces more maintenance burden than maintaining implementations in the callers' repos. We should eventually remove these.

https://github.com/argoproj/argo-cd/issues/22175